### PR TITLE
Add Agentlink to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - [Writing effective AGENTS.md files](https://blog.example.com/agents-md) – Practical tips to accelerate agent onboarding.
 
 ## Tools
-- [Agentlink](https://github.com/snapsynapse/agentlink) – Symlink-based CLI that keeps one AGENTS.md in sync with CLAUDE.md, GEMINI.md and other tool-specific instruction files, in repos and globally.
+- [Agentlink](https://github.com/snapsynapse/agentlink) – Symlinks one AGENTS.md to CLAUDE.md, GEMINI.md and more.
 - [awesome‑lint](https://github.com/sindresorhus/awesome-lint) – Linter that enforces Awesome List style.
 - [lychee](https://github.com/lycheeverse/lychee) – Fast, configurable link checker.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - [Writing effective AGENTS.md files](https://blog.example.com/agents-md) – Practical tips to accelerate agent onboarding.
 
 ## Tools
+- [Agentlink](https://github.com/snapsynapse/agentlink) – Symlink-based CLI that keeps one AGENTS.md in sync with CLAUDE.md, GEMINI.md and other tool-specific instruction files, in repos and globally.
 - [awesome‑lint](https://github.com/sindresorhus/awesome-lint) – Linter that enforces Awesome List style.
 - [lychee](https://github.com/lycheeverse/lychee) – Fast, configurable link checker.
 


### PR DESCRIPTION
Adds [Agentlink](https://github.com/snapsynapse/agentlink) to the Tools section.

Agentlink is a symlink-based CLI that keeps one AGENTS.md in sync with CLAUDE.md, GEMINI.md, .cursorrules and any other tool-specific instruction file path — in individual repos and globally under ~. It auto-detects installed AI tools, scans a directory tree to wire up every git repo, and installs git/shell hooks so the links stay correct. No code generation; the source file is the only real file.

MIT licensed, Go, macOS and Linux. Docs: https://agentlink.run/

I have read the contributing guidelines (unicorn).