### PR TITLE
Add Context Architecture (Tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 ## Tools
 - [awesome‑lint](https://github.com/sindresorhus/awesome-lint) – Linter that enforces Awesome List style.
 - [lychee](https://github.com/lycheeverse/lychee) – Fast, configurable link checker.
+- [Context Architecture](https://context-architecture.dev) – Specification and agent skill for making an existing codebase legible to people and AI agents: `AGENTS.md` at every boundary, conventions codified in lint and types, and every claim backed by a check that fails when it stops being true. [Skill](https://github.com/sergioazoc/context-architecture/tree/main/skills/context-architecture).
 
 ## License
 This work is released under **CC0‑1.0**. See [LICENSE](LICENSE).


### PR DESCRIPTION
Context Architecture is a specification and agent skill for structuring a codebase that already exists so it stays legible to people and AI agents: `AGENTS.md` at every boundary, conventions codified in lint and types, and every claim the repo makes backed by a check that fails when it stops being true. It is directly about placing and auditing `AGENTS.md`, so I added it under Tools (it could also fit Real-world Examples, since the repo itself ships AGENTS.md at every boundary; feel free to move it).

Site: https://context-architecture.dev
Skill: https://github.com/sergioazoc/context-architecture/tree/main/skills/context-architecture