### PR TITLE
Add AI Web Design Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 
 ## Guides & Articles
 - [A Quick Look at ChatGPT Codex – Apidog Blog](https://apidog.com/blog/openai-launches-chatgpt-codex-an-ai-coding-agent) – Visual overview with a five-point minimal template.
+- [AI Web Design Codex – Eneryleen](https://github.com/Eneryleen/ai-web-design-codex) – Web-design knowledge base with an AGENTS.md index for agents.
 - [ChatGPT Codex: The Missing Manual – Latent Space](https://www.latent.space/p/codex) – Detailed format guidance in 'Groom your Agents.md'.
 - [Create an AGENTS.md file in your repo – Medium (Joe Njenga)](https://medium.com/@joe.njenga/openai-new-codex-agent-the-fully-agentic-coding-best-coding-agent-8fae9810a888) – Shares a sub-30 line minimal template with examples.
 - [OpenAI Codex: A Guide With 3 Practical Examples – DataCamp](https://www.datacamp.com/tutorial/openai-codex) – Step-by-step tutorial including three AGENTS.md samples.


### PR DESCRIPTION
Adds **AI Web Design Codex** to *Guides & Articles* — a 60-guide web-design / UX / conversion knowledge base that ships an `AGENTS.md` machine index with per-task reading paths, so a coding agent reads the 2–5 relevant guides instead of the whole repo.

- Repo: https://github.com/Eneryleen/ai-web-design-codex
- License: CC BY 4.0
- Inserted alphabetically in **Guides & Articles**; format matches existing entries (en-dash separator, description ends with a period).

I have read the contributing guidelines (unicorn 🦄).