### PR TITLE
Add Superself

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 ## Tools
 - [awesome‑lint](https://github.com/sindresorhus/awesome-lint) – Linter that enforces Awesome List style.
 - [lychee](https://github.com/lycheeverse/lychee) – Fast, configurable link checker.
+- [Superself](https://github.com/fxylabs/superself) – Version control for project state; renders AGENTS.md blocks.
 
 ## License
 This work is released under **CC0‑1.0**. See [LICENSE](LICENSE).


### PR DESCRIPTION
### Description
Add Superself to Tools.

Disclosure: I maintain Superself. It is an Apache-2.0 CLI (`npm install -g superself`) that version-controls a project's state — goals, decisions, work units, reports — as an append-only event log in a git repo separate from the code; `self connect` renders a managed block into AGENTS.md/CLAUDE.md and `self context` prints the derived context an agent reads at session start. It fits Tools because it is a tool that writes and maintains AGENTS.md content rather than an example or template. The entry follows the `- [Name](URL) – description` format (60 characters), sorted after lychee. I ran `npm run lint`: awesome-lint reports the same pre-existing errors on `main` (en-dash separator, heading/badge/license rules) and this line adds one of the same class as the two existing Tools lines, nothing new. `npm run check-links` could not resolve `npx lychee` on my machine, so I verified the new link returns HTTP 200 directly.

### Checklist
- [x] I have read the **CONTRIBUTING** guide.
- [x] My entry follows the required format.
- [x] I have checked for duplicates.
- [x] I ran `npm run lint`; `npm run check-links` did not run (lychee not resolvable via npx), link verified manually.
- [ ] I reviewed two other PRs.

_unicorn_
