### PR TITLE
Add rulebisect

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 ## Tools
 - [awesome‑lint](https://github.com/sindresorhus/awesome-lint) – Linter that enforces Awesome List style.
 - [lychee](https://github.com/lycheeverse/lychee) – Fast, configurable link checker.
+- [rulebisect](https://github.com/T4LEL/rulebisect) – Bisects AGENTS.md to find the rule that hurts your agent.
 
 ## License
 This work is released under **CC0‑1.0**. See [LICENSE](LICENSE).


### PR DESCRIPTION
Adds [rulebisect](https://github.com/T4LEL/rulebisect) to Tools, alphabetically after lychee.

rulebisect applies `git bisect` and delta debugging to an AGENTS.md (or CLAUDE.md) file: it runs your agent against a small eval with subsets of the rules and reports which single rule made the results worse. Entry follows the `- [Name](URL) – description.` format, description is 57 characters.

unicorn

Disclosure: I am the author.
