### PR TITLE
Add AgentReady (AGENTS.md generator) to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - [Writing effective AGENTS.md files](https://blog.example.com/agents-md) – Practical tips to accelerate agent onboarding.
 
 ## Tools
-- [AgentReady](https://getagentready.dev) – Free web + CLI generator ([source](https://github.com/cyberpatrolunit/agentready), MIT) that builds a tailored AGENTS.md/CLAUDE.md from a repo manifest; detects 30+ frameworks, fully client‑side.
+- [AgentReady](https://getagentready.dev) – Generates a tailored AGENTS.md from your repo manifest.
 - [awesome‑lint](https://github.com/sindresorhus/awesome-lint) – Linter that enforces Awesome List style.
 - [lychee](https://github.com/lycheeverse/lychee) – Fast, configurable link checker.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - [Writing effective AGENTS.md files](https://blog.example.com/agents-md) – Practical tips to accelerate agent onboarding.
 
 ## Tools
-- [AgentReady](https://getagentready.dev) – Generates a tailored AGENTS.md from your repo manifest.
+- [AgentReady](https://github.com/cyberpatrolunit/agentready) – Generates a tailored AGENTS.md from your repo manifest.
 - [awesome‑lint](https://github.com/sindresorhus/awesome-lint) – Linter that enforces Awesome List style.
 - [lychee](https://github.com/lycheeverse/lychee) – Fast, configurable link checker.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - [Writing effective AGENTS.md files](https://blog.example.com/agents-md) – Practical tips to accelerate agent onboarding.
 
 ## Tools
+- [AgentReady](https://getagentready.dev) – Free web + CLI generator ([source](https://github.com/cyberpatrolunit/agentready), MIT) that builds a tailored AGENTS.md/CLAUDE.md from a repo manifest; detects 30+ frameworks, fully client‑side.
 - [awesome‑lint](https://github.com/sindresorhus/awesome-lint) – Linter that enforces Awesome List style.
 - [lychee](https://github.com/lycheeverse/lychee) – Fast, configurable link checker.
 


### PR DESCRIPTION
Adds AgentReady — a free, MIT-licensed web + CLI generator that produces a tailored AGENTS.md (and CLAUDE.md) from a repo's manifest (package.json, pyproject.toml, Cargo.toml, go.mod, …). Detects 30+ frameworks and emits exact install/test/lint commands, conventions, and stack gotchas. Web version runs entirely client-side; CLI is `npx getagentready`.

Disclosure: I'm the author of the tool.

🦄 unicorn