### PR TITLE
Add Repo Agent Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 ## Tools
 - [awesome‑lint](https://github.com/sindresorhus/awesome-lint) – Linter that enforces Awesome List style.
 - [lychee](https://github.com/lycheeverse/lychee) – Fast, configurable link checker.
+- [Repo Agent Kit](https://repoagentkit.com/?utm_source=awesome-agents-md&utm_medium=directory&utm_campaign=agents-md) – Browser-private AGENTS.md generator, audits and CI.
 
 ## License
 This work is released under **CC0‑1.0**. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 ## Tools
 - [awesome‑lint](https://github.com/sindresorhus/awesome-lint) – Linter that enforces Awesome List style.
 - [lychee](https://github.com/lycheeverse/lychee) – Fast, configurable link checker.
-- [Repo Agent Kit](https://repoagentkit.com/?utm_source=awesome-agents-md&utm_medium=directory&utm_campaign=agents-md) – Browser-private AGENTS.md generator, audits and CI.
+- [Repo Agent Kit](https://repoagentkit.com/) – Browser-private AGENTS.md generator, audits and CI.
 
 ## License
 This work is released under **CC0‑1.0**. See [LICENSE](LICENSE).


### PR DESCRIPTION
Adds Repo Agent Kit to the Tools section as one alphabetized entry. It provides browser-private AGENTS.md generation and audits, plus the public CLI and GitHub Action.

Disclosure: I built and maintain this resource as part of a 30-day product experiment.

Validation:
- Reviewed open PRs #19 and #20.
- `git diff --check` passes.
- The clean added URL returns HTTP 200.
- The description is 51 characters and follows the requested format.
- `npm run lint` reports 22 existing errors on current upstream `main`; the new required-format separator adds the same known list-item class and no unrelated file changed.
- `npm run check-links` cannot resolve the repository's configured `npx lychee` executable on either base or this branch, so the added link was verified directly.
- Reviewer feedback was applied in `99eca74`: the directory entry now uses the clean homepage URL with no tracking parameters.

unicorn
