### PR TITLE
Add prumo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@
 ## Tools
 - [awesome‑lint](https://github.com/sindresorhus/awesome-lint) – Linter that enforces Awesome List style.
 - [lychee](https://github.com/lycheeverse/lychee) – Fast, configurable link checker.
+- [prumo](https://github.com/TomD4vs/prumo) – Checks AGENTS.md paths and links against git.
 
 ## License
 This work is released under **CC0‑1.0**. See [LICENSE](LICENSE).


### PR DESCRIPTION
Adds **prumo** to Tools, after lychee, keeping the section alphabetical.

prumo checks an `AGENTS.md` (and `CLAUDE.md`, `SKILL.md`, `.cursor/rules` and the rest) against the git index of the repository: paths whose letter case disagrees with git, broken links, paths that no longer exist, commands naming a script nothing defines. It is a zero-dependency CLI, `npx @tomd4vs/prumo`, with a GitHub Action and an MCP server in the same package. I maintain it and use it on my own repositories.

Repository: https://github.com/TomD4vs/prumo

unicorn
