### PR TITLE
Add driftlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 
 ## Tools
 - [awesome‑lint](https://github.com/sindresorhus/awesome-lint) – Linter that enforces Awesome List style.
+- [driftlint](https://github.com/alifurkangokce/driftlint) - Verifies AGENTS.md claims against the actual repo.
 - [lychee](https://github.com/lycheeverse/lychee) – Fast, configurable link checker.
 
 ## License


### PR DESCRIPTION
Adds [driftlint](https://github.com/alifurkangokce/driftlint) to Tools, alphabetically between `awesome-lint` and `lychee`.

Disclosure: I wrote it, and I use it on my own repositories daily — including on this fork while preparing this PR.

The Tools section currently covers whether a list is well-formed (awesome-lint) and whether its links resolve (lychee). driftlint covers a different question: whether the claims **inside** an AGENTS.md are still true. It resolves every referenced path, npm script and make target against the actual tree, and checks the limits that silently drop instructions — Codex truncating the concatenated AGENTS.md set at 32 KB, skill descriptions cut at 1,536 characters in the listing, and `.md` files under `.cursor/rules` that Cursor never reads. MIT, zero runtime dependencies, no account, nothing leaves the machine.

Checklist notes:

- **Format and sorting**: matches the section's shape and sits in the correct alphabetical position.
- **Lint**: `npm run lint` reports **21 errors on `main` before my change and 21 with it** — my entry adds none. All 21 are the same pre-existing `awesome-list-item` rule, because the file's entries use an en dash (`–`) while awesome-lint wants an ASCII hyphen. I used the ASCII hyphen so the new line is lint-clean rather than adding a 22nd error; if you would rather keep the file visually consistent with the en dash, say so and I'll switch it in a second.
- **Reviews**: reviewed #20 (AgentReady) and #19 (rulebisect) — placement, description length and links checked on both, with one non-blocking note each.

unicorn